### PR TITLE
Update when-last-reboot.ps1

### DIFF
--- a/servers/when-last-reboot.ps1
+++ b/servers/when-last-reboot.ps1
@@ -4,4 +4,4 @@ param(
     [Parameter(Mandatory = $True,valueFromPipeline=$true)][String] $serverName
     )
 
-Get-WmiObject -Class Win32_OperatingSystem -ComputerName $serverName | Select-Object CSName, LastBootupTime
+Get-WmiObject -Class Win32_OperatingSystem -ComputerName $serverName | Select-Object CSName, @{Name='LastBootupTime'; Expression={"$($($_.LastBootupTime).SubString(0,4))-$($($_.LastBootupTime).SubString(4,2))-$($($_.LastBootupTime).SubString(6,2)) $($($_.LastBootupTime).SubString(8,2)):$($($_.LastBootupTime).SubString(10,2))"}}


### PR DESCRIPTION
replaces the default LastBootupTime format (yyyyMMddhhmmss)
with more readable:  yyyy-MM-dd hh:mm